### PR TITLE
Add docs folder and example queries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Welcome to the documentation for eth.events
+
+Here, we will provide you with a documentation to get started with eth.events in a short time.
+Please be patient, thank you!
+
+

--- a/docs/example-queries/erc20_contract.json
+++ b/docs/example-queries/erc20_contract.json
@@ -1,0 +1,12 @@
+{
+  "query": {
+    "bool": {
+      "filter":
+        {
+          "term": {
+            "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"
+          }
+        }
+    }
+  }
+}

--- a/docs/example-queries/erc20_event_sorted.json
+++ b/docs/example-queries/erc20_event_sorted.json
@@ -1,0 +1,24 @@
+{
+   "query":{
+      "bool":{
+         "filter":[
+            {
+               "term":{
+                  "event.keyword":"Transfer"
+               }
+            },
+            {
+               "term":{
+                  "address":"0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"
+               }
+            }
+         ]
+      }
+   },
+   "sort":{
+      "blockNumber.num":{
+         "order":"desc"
+      }
+   },
+   "size":5
+}

--- a/docs/example-queries/erc20_event_type.json
+++ b/docs/example-queries/erc20_event_type.json
@@ -1,0 +1,18 @@
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.keyword": "Transfer"
+          }
+        },
+        {
+          "term": {
+            "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
In order to serve some raw JSON files for use in the eth.events query tutorial,
3 queries were included in a new `docs` folder.

This folder is proposed as a place for the coming eth.events docs, which should get served directly from GitHub as Markdown files.